### PR TITLE
Redirect PortgreSQL tools check output to stderr

### DIFF
--- a/commands
+++ b/commands
@@ -33,7 +33,7 @@ function check_postgresql_container() {
 function check_postgresql_tool() {
     local tool_name="$1"
     if [[ $(whereis $tool_name | awk '{ print NF }') -eq 1 ]]; then
-        echo "'${tool_name}' not found. Is the package 'postgresql-client' installed?"
+        echo "'${tool_name}' not found. Is the package 'postgresql-client' installed?" 1>&2
         exit 1
     fi
 }


### PR DESCRIPTION
Fixes a bug [found by Steven Yang](https://github.com/Kloadut/dokku-pg-plugin/pull/29#issuecomment-38789249) (@yangchenyun).

When the `pg_dump` executable is not found, the error message, instead of being shown on the terminal, were redirect to the file that is expected to contain only the database dump.
