### PR TITLE
Not start postgresql if vloume file does not exist

### DIFF
--- a/pre-deploy
+++ b/pre-deploy
@@ -4,10 +4,11 @@ set -e;
 APP="$1"
 
 PG_APP_IMAGE="postgresql/$APP"
+PG_VOLUME_PATH="$DOKKU_ROOT/.postgresql/volume_$APP"
 
 # Check if an existing DB volume exists
 PG_APP_IMAGE_ID=$(docker images | grep "$PG_APP_IMAGE" |  awk '{print $3}')
-if [[ -n $PG_APP_IMAGE_ID ]]; then
+if [[ -n $PG_APP_IMAGE_ID ]] && [[ -f $PG_VOLUME_PATH ]]; then
     echo    "-----> Checking status of PostgreSQL"
 
     # Check if DB container is installed
@@ -26,7 +27,7 @@ if [[ -n $PG_APP_IMAGE_ID ]]; then
     else
         echo "stopped."
 
-        PG_VOLUME="`cat $DOKKU_ROOT/.postgresql/volume_$APP`:/opt/postgresql"
+        PG_VOLUME="`cat $PG_VOLUME_PATH`:/opt/postgresql"
         PG_PORT="`cat $DOKKU_ROOT/.postgresql/port_$APP`"
 
         echo -n "       Launching $PG_APP_IMAGE... "


### PR DESCRIPTION
Now this hook try to start postgresql in all applications, even those that do not use.
As a result, initd daemon failures when try to up postgresql container in which it is not present.
