### PR TITLE
Fix for issue #50 - ports remapping on server/docker restart

### DIFF
--- a/commands
+++ b/commands
@@ -104,7 +104,7 @@ case "$1" in
         echo $VOLUME_PATH > "$DOKKU_ROOT/.postgresql/volume_$APP"
     fi
     # Link to a potential existing app
-    dokku postgresql:links $APP $APP
+    dokku postgresql:link $APP $APP
     echo
     echo "-----> PostgreSQL container created: $DB_IMAGE"
     sleep 1


### PR DESCRIPTION
This fix ensures the postgresql commands inspect docker for the correct port, rather than stashing the port number in a file. If the server reboots, docker won't necessarily reassign the same port to the container. 

Also includes a slight refactor for getting the ID of a container.
