### PR TITLE
draft to use DOKKU_NOT_IMPLEMENTED_EXIT on unknown command, fix #72

### DIFF
--- a/commands
+++ b/commands
@@ -239,4 +239,8 @@ case "$1" in
 EOF
     ;;
 
+  *)
+    exit $DOKKU_NOT_IMPLEMENTED_EXIT
+    ;;
+
 esac


### PR DESCRIPTION
To be honest, its not tested :(, consider it a draft.
